### PR TITLE
Fix dataloader length calculation

### DIFF
--- a/pinnstorch/data/dataloader/dataloader.py
+++ b/pinnstorch/data/dataloader/dataloader.py
@@ -37,7 +37,7 @@ class PINNDataLoader:
         if self.ignore:
             return self.dataset_size // self.batch_size
         else:
-            return (self.dataset_size // self.batch_size) + 1
+            return (self.dataset_size + self.batch_size - 1) // self.batch_size
 
     def __iter__(self):
         """Initialize the data loader iterator.


### PR DESCRIPTION
## Summary
- fix batch count logic in `PINNDataLoader.__len__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rootutils')*

------
https://chatgpt.com/codex/tasks/task_e_684b68b027b88330b730ecb1c2987283