### PR TITLE
Add wave equation example

### DIFF
--- a/examples/wave_equation/README.md
+++ b/examples/wave_equation/README.md
@@ -1,0 +1,27 @@
+# Wave Equation
+
+## Problem
+
+Solves the 1D wave equation using a physics-informed neural network:
+
+$$u_{tt} = c^2 u_{xx}, \quad x \in [0, 1], \quad t \in [0, 1]$$
+
+with Dirichlet boundary conditions $u(0, t) = u(1, t) = 0$ and initial conditions:
+
+- $u(x, 0) = \sin(\pi x)$
+- $u_t(x, 0) = 0$
+
+The exact solution is $u(x, t) = \sin(\pi x)\cos(\pi c t)$ with wave speed $c = 1$.
+
+## Features
+
+- Demonstrates PINN training on a **hyperbolic** PDE (wave propagation)
+- Reference data generated analytically (no `.mat` file needed)
+- Enforces both initial displacement and zero initial velocity via `output_fn`
+- Complements the existing parabolic (heat/diffusion) and dispersive (Schrödinger, KdV) examples
+
+## Usage
+
+```bash
+python train.py
+```

--- a/examples/wave_equation/configs/config.yaml
+++ b/examples/wave_equation/configs/config.yaml
@@ -1,0 +1,75 @@
+defaults:
+  - train
+  - _self_
+
+N0: 100
+N_b: 100
+N_f: 10_000
+
+time_domain:
+  _target_: pinnstorch.data.TimeDomain
+  t_interval: [0, 1.0]
+  t_points: 201
+
+spatial_domain:
+  _target_: pinnstorch.data.Interval
+  x_interval: [0, 1]
+  shape: [256, 1]
+
+mesh:
+  _target_: pinnstorch.data.Mesh
+  root_dir: null
+  read_data_fn: ???
+  ub: [1.0, 1.0]
+  lb: [0.0, 0.0]
+
+train_datasets:
+  - mesh_sampler:
+      _target_: pinnstorch.data.MeshSampler
+      _partial_: true
+      num_sample: ${N_f}
+      collection_points:
+        - f
+
+  - initial_condition:
+      _target_: pinnstorch.data.InitialCondition
+      _partial_: true
+      num_sample: ${N0}
+      solution:
+        - u
+        - v
+
+  - dirichlet_boundary_condition:
+      _target_: pinnstorch.data.DirichletBoundaryCondition
+      _partial_: true
+      num_sample: ${N_b}
+      solution:
+        - u
+
+val_dataset:
+  - mesh_sampler:
+      _target_: pinnstorch.data.MeshSampler
+      _partial_: true
+      solution:
+        - u
+
+pred_dataset:
+  - mesh_sampler:
+      _target_: pinnstorch.data.MeshSampler
+      _partial_: true
+      solution:
+        - u
+
+net:
+  _target_: pinnstorch.models.FCN
+  layers: [2, 50, 50, 50, 50, 50, 1]
+  output_names:
+    - u
+
+trainer:
+  accelerator: gpu
+  max_epochs: 20000
+  devices:
+    - 0
+  deterministic: false
+  check_val_every_n_epoch: 20001

--- a/examples/wave_equation/train.py
+++ b/examples/wave_equation/train.py
@@ -1,0 +1,65 @@
+from typing import Dict, Optional
+
+import hydra
+import numpy as np
+import torch
+from omegaconf import DictConfig
+
+import pinnstorch
+
+
+C = 1.0  # wave speed
+
+
+def read_data_fn(root_path):
+    """Generate analytical reference data for 1D wave equation.
+
+    Exact solution: u(x, t) = sin(pi*x) * cos(pi*c*t)
+    satisfying u_tt = c^2 * u_xx with u(0,t)=u(1,t)=0.
+    """
+    nx, nt = 256, 201
+    x = np.linspace(0, 1, nx)
+    t = np.linspace(0, 1, nt)
+    X, T = np.meshgrid(x, t, indexing="ij")
+    exact_u = np.sin(np.pi * X) * np.cos(np.pi * C * T)
+    return {"u": exact_u}
+
+
+def pde_fn(
+    outputs: Dict[str, torch.Tensor],
+    x: torch.Tensor,
+    t: torch.Tensor,
+):
+    """Define the wave equation PDE residual: u_tt - c^2 * u_xx = 0."""
+    u_x, u_t = pinnstorch.utils.gradient(outputs["u"], [x, t])
+    u_xx = pinnstorch.utils.gradient(u_x, x)[0]
+    u_tt = pinnstorch.utils.gradient(u_t, t)[0]
+    outputs["f"] = u_tt - C**2 * u_xx
+    return outputs
+
+
+def output_fn(
+    outputs: Dict[str, torch.Tensor],
+    x: torch.Tensor,
+    t: torch.Tensor,
+):
+    """Compute velocity field for initial velocity enforcement."""
+    outputs["v"] = pinnstorch.utils.gradient(outputs["u"], t)[0]
+    return outputs
+
+
+@hydra.main(version_base="1.3", config_path="configs", config_name="config.yaml")
+def main(cfg: DictConfig) -> Optional[float]:
+    """Main entry point for training."""
+    pinnstorch.utils.extras(cfg)
+    metric_dict, _ = pinnstorch.train(
+        cfg, read_data_fn=read_data_fn, pde_fn=pde_fn, output_fn=output_fn
+    )
+    metric_value = pinnstorch.utils.get_metric_value(
+        metric_dict=metric_dict, metric_names=cfg.get("optimized_metric")
+    )
+    return metric_value
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a 1D wave equation example (\u_tt = c² u_xx\), filling a gap in the example suite which currently covers parabolic (diffusion via Burgers), dispersive (Schrödinger, KdV), and nonlinear (Navier-Stokes) equations but has **no hyperbolic wave equation**.

## New Files

### \examples/wave_equation/train.py\
- Solves \u_tt = c² u_xx\ on \[0,1] × [0,1]\ with Dirichlet BCs
- Exact solution: \u(x,t) = sin(πx)cos(πct)\ with \c = 1\
- Reference data generated analytically in \ead_data_fn\ (no \.mat\ file needed)
- Enforces both initial displacement and zero initial velocity using \output_fn\
- PDE residual: \ = u_tt - c² u_xx\ via automatic differentiation

### \examples/wave_equation/configs/config.yaml\
- 256×201 mesh, 10k collocation points, 100 IC/BC points
- 5-layer FCN (50 neurons each), 20k epochs

### \examples/wave_equation/README.md\
- Problem description, math formulation, usage instructions

## Motivation

The wave equation is one of the three fundamental linear PDEs alongside heat/Laplace. Having a wave equation example:
- Demonstrates PINNs on **hyperbolic** PDEs (second-order in time)
- Shows how to enforce initial velocity conditions via \output_fn\
- Provides a clean baseline for users working on acoustics, seismology, or electromagnetic wave problems